### PR TITLE
Migrate to null-safe, newer version of http.

### DIFF
--- a/example/requester_example.dart
+++ b/example/requester_example.dart
@@ -36,8 +36,8 @@ class LoggingMiddleware extends BaseMiddleware {
     curlCmd += " -X " + request.method;
     var compressed = false;
     request.headers.forEach((name, value) {
-      if (name?.toLowerCase() == "accept-encoding" &&
-          value?.toLowerCase() == "gzip") {
+      if (name.toLowerCase() == "accept-encoding" &&
+          value.toLowerCase() == "gzip") {
         compressed = true;
       }
       curlCmd += " -H \"$name: $value\"";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/johnpryan/requester
 author: John Ryan <john.p.ryan4@gmail.com>
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  http: ^0.12.1
+  http: ^0.13.0


### PR DESCRIPTION
No changes required to make code null safe, except for in the example.